### PR TITLE
AI resist do_after fix

### DIFF
--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -25,8 +25,7 @@
 
 /obj/item/organ/internal/zombie_infection/on_mob_insert(mob/living/carbon/M, special = FALSE, movement_flags)
 	. = ..()
-	if(!.)
-		return .
+
 	START_PROCESSING(SSobj, src)
 
 /obj/item/organ/internal/zombie_infection/on_mob_remove(mob/living/carbon/M, special = FALSE)

--- a/html/changelogs/AutoChangeLog-pr-80293.yml
+++ b/html/changelogs/AutoChangeLog-pr-80293.yml
@@ -1,0 +1,4 @@
+author: "jlsnow301"
+delete-after: True
+changes:
+  - bugfix: "Newscaster shouldn't bluescreen anymore."

--- a/html/changelogs/AutoChangeLog-pr-80303.yml
+++ b/html/changelogs/AutoChangeLog-pr-80303.yml
@@ -1,0 +1,4 @@
+author: "Time-Green"
+delete-after: True
+changes:
+  - bugfix: "fixes zombie tumor not reviving"

--- a/tgui/packages/tgui/interfaces/Newscaster.jsx
+++ b/tgui/packages/tgui/interfaces/Newscaster.jsx
@@ -603,10 +603,9 @@ const NewscasterChannelMessages = (props) => {
                   the station and therefore marked with a <b>D-Notice</b>.
                 </Section>
               ) : (
-                <Section
-                  dangerouslySetInnerHTML={processedText(message.body)}
-                  pl={1}
-                />
+                <Section pl={1}>
+                  <Box dangerouslySetInnerHTML={processedText(message.body)} />
+                </Section>
               )}
               {message.photo !== null && !message.censored_message && (
                 <Box as="img" src={message.photo} />
@@ -618,10 +617,11 @@ const NewscasterChannelMessages = (props) => {
                       <Box italic textColor="white">
                         By: {comment.auth} at {comment.time}
                       </Box>
-                      <Section
-                        dangerouslySetInnerHTML={processedText(comment.body)}
-                        ml={2.5}
-                      />
+                      <Section ml={2.5}>
+                        <Box
+                          dangerouslySetInnerHTML={processedText(comment.body)}
+                        />
+                      </Section>
                     </BlockQuote>
                   ))}
                 </Box>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Prevents ai controllers from interrupting resisting do_afters by blocking their processing while resisting and in a do_after for it. Adds a blackboard value for ai to record if they activated the resist chain, and if they're in a state that should necessitate resisting, maintains that value. Otherwise if they don't need to resist anymore, changes the value to false and allows them to process again.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Allows monkeys to resist out of cuffs and their ai doesn't completely freeze up when they're aggressively grabbed or cuffed.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: monkeys don't freeze when restrained and now will resist out of cuffs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
